### PR TITLE
Don't crash process on error or debug message

### DIFF
--- a/include/ode/error.h
+++ b/include/ode/error.h
@@ -50,9 +50,9 @@ ODE_API dMessageFunction *dGetErrorHandler(void);
 ODE_API dMessageFunction *dGetDebugHandler(void);
 ODE_API dMessageFunction *dGetMessageHandler(void);
 
-/* generate a fatal error, debug trap or a message. */
-ODE_API void ODE_NORETURN dError (int num, const char *msg, ...);
-ODE_API void ODE_NORETURN dDebug (int num, const char *msg, ...);
+/* generate an error, debug trap or a message. */
+ODE_API void dError (int num, const char *msg, ...);
+ODE_API void dDebug (int num, const char *msg, ...);
 ODE_API void dMessage (int num, const char *msg, ...);
 
 

--- a/ode/src/error.cpp
+++ b/ode/src/error.cpp
@@ -90,7 +90,6 @@ extern "C" void dError (int num, const char *msg, ...)
     if (error_function) error_function (num,msg,ap);
     else printMessage (num,"ODE Error",msg,ap);
     va_end (ap);
-    exit (1);
 }
 
 
@@ -101,8 +100,6 @@ extern "C" void dDebug (int num, const char *msg, ...)
     if (debug_function) debug_function (num,msg,ap);
     else printMessage (num,"ODE INTERNAL ERROR",msg,ap);
     va_end (ap);
-    // *((char *)0) = 0;   ... commit SEGVicide
-    abort();
 }
 
 


### PR DESCRIPTION
ODE normally crashes when assert fails or some other error is detected.
For lovr it is preferred to continue running instead because crashes in
VR are unpleasant. It is safe to continue running the physics engine
even after these errors, this is what dNODEBUG flag does.